### PR TITLE
Updated form frequency and days of week to pill-like buttons

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -1,3 +1,6 @@
+.create-form-container {
+  padding: 0px 60px;
+}
 .category-icons {
   display: flex;
   flex-wrap: wrap;
@@ -36,4 +39,46 @@
   display: block;
   margin-top: 0.5rem;
   font-size: 10px !important;
+}
+
+.days-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  .day-pill {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    cursor: pointer;
+    background-color: #f8f9fa;
+    transition: background-color 0.3s ease;
+    font-size: 12px;
+
+    &.selected {
+      background-color: #670BFF;
+      color: white;
+    }
+  }
+}
+
+.frequency-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  .frequency-pill {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    background-color: #f8f9fa;
+    transition: background-color 0.3s ease;
+    font-size: 12px;
+    cursor: pointer;
+
+    &.selected {
+      background-color: #670BFF;
+      color: white;
+    }
+  }
 }

--- a/app/javascript/controllers/days_selector_controller.js
+++ b/app/javascript/controllers/days_selector_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["daysInput", "pill"]
+
+  connect() {
+    // Initialize selectedDays as an empty array to ensure no pills are selected by default
+    this.selectedDays = []
+    this.updateSelectedPills()
+  }
+
+  toggleDay(event) {
+    const day = event.currentTarget.dataset.day
+    if (this.selectedDays.includes(day)) {
+      this.selectedDays = this.selectedDays.filter(selectedDay => selectedDay !== day)
+    } else {
+      this.selectedDays.push(day)
+    }
+    this.daysInputTarget.value = this.selectedDays.join(',')
+    this.updateSelectedPills()
+  }
+
+  updateSelectedPills() {
+    this.pillTargets.forEach(pill => {
+      if (this.selectedDays.includes(pill.dataset.day)) {
+        pill.classList.add("selected")
+      } else {
+        pill.classList.remove("selected")
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/frequency_selector_controller.js
+++ b/app/javascript/controllers/frequency_selector_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["frequencyInput", "pill"]
+
+  connect() {
+    this.selectedFrequency = this.frequencyInputTarget.value
+    this.updateSelectedPills()
+  }
+
+  toggleFrequency(event) {
+    const frequency = event.currentTarget.dataset.frequency
+    if (this.selectedFrequency === frequency) {
+      this.selectedFrequency = null
+    } else {
+      this.selectedFrequency = frequency
+    }
+    this.frequencyInputTarget.value = this.selectedFrequency
+    this.updateSelectedPills()
+    this.toggleAdditionalOptions()
+  }
+
+  updateSelectedPills() {
+    this.pillTargets.forEach(pill => {
+      if (pill.dataset.frequency === this.selectedFrequency) {
+        pill.classList.add("selected")
+      } else {
+        pill.classList.remove("selected")
+      }
+    })
+  }
+
+  toggleAdditionalOptions() {
+    // Example: Toggle visibility of days of the week based on selected frequency
+    const daysOfWeekContainer = document.querySelector('.days-label-input')
+    if (this.selectedFrequency === 'weekly') {
+      daysOfWeekContainer.classList.remove('d-none')
+    } else {
+      daysOfWeekContainer.classList.add('d-none')
+    }
+  }
+}

--- a/app/views/habits/_form.html.erb
+++ b/app/views/habits/_form.html.erb
@@ -5,12 +5,12 @@
       <div class="breakpoint" data-controller="frequency">
 
         <div class="habit-label-input">
-          <%= f.label :name, 'Habit', class: "habit-label-field col-2" %>
+          <%= f.label :name, 'Habit', class: "habit-label-field col-2 mb-2" %>
           <%= f.input :name, label: false, required: true, class: "col-10" %>
         </div>
 
         <%= f.label :name, 'Category', class: "habit-label-field col-2 mb-2" %>
-        <div class="category-icons" data-controller="category-selector">
+        <div class="category-icons mb-2" data-controller="category-selector">
           <%= f.hidden_field :category, value: f.object.category, data: { target: "category-selector.categoryInput" } %>
           <% Habit::CATEGORIES.each do |category, icon_class| %>
             <div class="icon-div">
@@ -25,27 +25,47 @@
         </div>
 
         <div class="description-label-input">
-          <%= f.label :description, 'Description', class: "habit-label-field" %>
+          <%= f.label :description, 'Description', class: "habit-label-field mb-2" %>
           <%= f.input :description, label: false, as: :text,required: false %>
         </div>
 
-        <div class="frequency-label-input">
-          <%= f.label :frequency, 'Frequency', class: "habit-label-field" %>
-          <%= f.input :frequency, collection: Habit::FREQUENCIES, label: false, input_html: { data: { target: "frequency.frequency", action: "change->frequency#toggleDaysOfWeek" } } %>
-        </div>
+      <div class="frequency-label-input" data-controller="frequency-selector">
+        <%= f.label :frequency, 'Frequency', class: "habit-label-field mb-2" %>
+        <%= f.hidden_field :frequency, value: f.object.frequency, data: { target: "frequency-selector.frequencyInput" } %>
 
-        <div class="days-label-input d-none" data-target="frequency.daysOfWeek">
-          <%= f.label :days_of_week, 'Days of the week', class: "habit-label-field" %>
-          <%= f.input :days_of_week, collection: Habit::DAYS_OF_WEEK, as: :select, input_html: { multiple: true }, label: false %>
+        <div class="frequency-pills mb-2">
+          <% Habit::FREQUENCIES.each do |frequency| %>
+            <div class="frequency-pill" data-frequency-selector-target="pill"
+                 data-action="click->frequency-selector#toggleFrequency"
+                 data-frequency="<%= frequency %>">
+              <span><%= frequency.capitalize %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+        <div class="days-label-input d-none" data-controller="days-selector" data-target="frequency.daysOfWeek">
+          <%= f.label :days_of_week, 'Days of the week', class: "habit-label-field mb-2" %>
+          <%= f.hidden_field :days_of_week, value: f.object.days_of_week.join(','), data: { target: "days-selector.daysInput" } %>
+
+          <div class="days-pills mb-2">
+            <% Habit::DAYS_OF_WEEK.each do |day| %>
+              <div class="day-pill" data-days-selector-target="pill"
+                   data-action="click->days-selector#toggleDay"
+                   data-day="<%= day %>">
+                <span><%= day %></span>
+              </div>
+            <% end %>
+          </div>
         </div>
 
         <div class="start-date-label-input">
-          <%= f.label :start_date, 'Start date', class: "habit-label-field" %>
+          <%= f.label :start_date, 'Start date', class: "habit-label-field mb-2" %>
           <%= f.input :start_date, label: false, as: :string, input_html: { data: { controller: "datepicker" } } %>
         </div>
 
         <div class="end-date-label-input">
-          <%= f.label :end_date, 'End date', class: "habit-label-field" %>
+          <%= f.label :end_date, 'End date', class: "habit-label-field mb-2" %>
           <%= f.input :end_date, label: false, as: :string, input_html: { data: { controller: "datepicker" } } %>
         </div>
 


### PR DESCRIPTION
Replaced dropdowns with pill-like buttons for selecting frequency and days_of_week.
Implemented Stimulus controllers to manage selection state and update hidden input fields.
Styled pills be in-line with app design. See screenshots!

<img width="952" alt="Screenshot 2024-07-10 at 20 47 47" src="https://github.com/Thuthikaran/habit-pulse/assets/68972820/38286650-b4c1-4c96-b27c-e20e550a42bd">
<img width="969" alt="Screenshot 2024-07-10 at 20 48 02" src="https://github.com/Thuthikaran/habit-pulse/assets/68972820/f0d3af19-71e7-41b4-b174-8b2afed3c44d">
